### PR TITLE
feat(js): Added toggle to hide the percentage inside the bar

### DIFF
--- a/progressbar/html/progressbar.js
+++ b/progressbar/html/progressbar.js
@@ -6,6 +6,7 @@ $(function () {
     var interrupting = false;
     var label = "Loading .. ";
     var duration = 10; //Seconds
+    var hidePercentageInsideBar = true // Hide the % inside theBar
 
     function display(bool) {
         if (bool) {
@@ -83,7 +84,9 @@ $(function () {
                     {
                         width++;
                         theBar.style.width = width + "%";
-                        //theBar.innerHTML = width + "%";
+                        if (!hidePercentageInsideBar) {
+                            theBar.innerHTML = width + "%";
+                        }
                     }
                 }
             }
@@ -104,7 +107,9 @@ $(function () {
     function resetBar()
     {
         theBar.style.width = 0 + "%";
-        theBar.innerHTML = 0 + "%";
+         if (!hidePercentageInsideBar) {
+            theBar.innerHTML = 0 + '%';
+        }
         theBar.style.backgroundColor = "#1b1a1a";
         $.post('https://progressbar/exit', JSON.stringify({}));
     }


### PR DESCRIPTION
In function **resetBar()** line 107: `theBar.innerHTML = 0 + "%";` was uncommented but in function **move()** line 86: `//theBar.innerHTML = width + "%";` was commented. 

I added an toggle to have both possibilities easily and fix the issue that before it showed the first progressbar without the percentage and then it showed "0 %" for the next progress bars!